### PR TITLE
feat(app): Recipe Runner UI wired to YAML runner + tests

### DIFF
--- a/RefactorStudio.Adapters/EchoAdapter.cs
+++ b/RefactorStudio.Adapters/EchoAdapter.cs
@@ -1,0 +1,11 @@
+using RefactorStudio.Core.Models;
+
+namespace RefactorStudio.Adapters;
+
+public class EchoAdapter : IModelAdapter
+{
+    public Task<string> ExecuteAsync(string prompt)
+    {
+        return Task.FromResult(prompt);
+    }
+}

--- a/RefactorStudio.Adapters/RefactorStudio.Adapters.csproj
+++ b/RefactorStudio.Adapters/RefactorStudio.Adapters.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\RefactorStudio.Core\RefactorStudio.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/RefactorStudio.App/MainPage.xaml
+++ b/RefactorStudio.App/MainPage.xaml
@@ -26,9 +26,13 @@
 
             <Button
                 x:Name="CounterBtn"
-                Text="Click me" 
+                Text="Click me"
                 SemanticProperties.Hint="Counts the number of times you click"
                 Clicked="OnCounterClicked"
+                HorizontalOptions="Fill" />
+            <Button
+                Text="Run Recipe"
+                Clicked="OnRunRecipeClicked"
                 HorizontalOptions="Fill" />
         </VerticalStackLayout>
     </ScrollView>

--- a/RefactorStudio.App/MainPage.xaml.cs
+++ b/RefactorStudio.App/MainPage.xaml.cs
@@ -1,23 +1,52 @@
+using Microsoft.Maui.Storage;
+using RefactorStudio.Adapters;
+using RefactorStudio.Core.Services;
+using System.Collections.Generic;
+using System.IO;
+
 ﻿namespace RefactorStudio.App;
 
 public partial class MainPage : ContentPage
 {
-	int count = 0;
+        int count = 0;
 
-	public MainPage()
-	{
-		InitializeComponent();
-	}
+        public MainPage()
+        {
+                InitializeComponent();
+        }
 
 	private void OnCounterClicked(object? sender, EventArgs e)
-	{
-		count++;
+        {
+                count++;
 
 		if (count == 1)
 			CounterBtn.Text = $"Clicked {count} time";
 		else
 			CounterBtn.Text = $"Clicked {count} times";
 
-		SemanticScreenReader.Announce(CounterBtn.Text);
-	}
+                SemanticScreenReader.Announce(CounterBtn.Text);
+        }
+
+        private async void OnRunRecipeClicked(object? sender, EventArgs e)
+        {
+                var file = await FilePicker.Default.PickAsync(new PickOptions
+                {
+                        PickerTitle = "Select recipe",
+                        FileTypes = new FilePickerFileType(new Dictionary<Microsoft.Maui.Devices.DevicePlatform, IEnumerable<string>>
+                        {
+                                { Microsoft.Maui.Devices.DevicePlatform.WinUI, new[] { ".yaml", ".yml" } },
+                                { Microsoft.Maui.Devices.DevicePlatform.Unknown, new[] { ".yaml", ".yml" } }
+                        })
+                });
+                if (file == null)
+                        return;
+
+                if (!file.FullPath.Contains(Path.Combine("RefactorStudio.Recipes", "samples")))
+                        return;
+
+                var recipe = RecipeLoader.Load(file.FullPath);
+                var adapter = new EchoAdapter();
+                var runner = new RecipeRunnerYaml(adapter);
+                await runner.RunAsync(recipe);
+        }
 }

--- a/RefactorStudio.App/RefactorStudio.App.csproj
+++ b/RefactorStudio.App/RefactorStudio.App.csproj
@@ -22,4 +22,9 @@
     <PackageReference Include="Microsoft.Maui.Graphics.Win2D.WinUI.Desktop" Version="8.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.*" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RefactorStudio.Core\RefactorStudio.Core.csproj" />
+    <ProjectReference Include="..\RefactorStudio.Adapters\RefactorStudio.Adapters.csproj" />
+  </ItemGroup>
 </Project>

--- a/RefactorStudio.Core/Models/IModelAdapter.cs
+++ b/RefactorStudio.Core/Models/IModelAdapter.cs
@@ -1,0 +1,6 @@
+namespace RefactorStudio.Core.Models;
+
+public interface IModelAdapter
+{
+    Task<string> ExecuteAsync(string prompt);
+}

--- a/RefactorStudio.Core/Models/RecipeYaml.cs
+++ b/RefactorStudio.Core/Models/RecipeYaml.cs
@@ -1,0 +1,16 @@
+namespace RefactorStudio.Core.Models;
+
+public class RecipeYaml
+{
+    public string Id { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
+     public string? Description { get; set; }
+    public List<RecipeStep> Steps { get; set; } = new();
+}
+
+public class RecipeStep
+{
+    public string Name { get; set; } = string.Empty;
+    public string Prompt { get; set; } = string.Empty;
+    public List<string> Outputs { get; set; } = new();
+}

--- a/RefactorStudio.Core/RefactorStudio.Core.csproj
+++ b/RefactorStudio.Core/RefactorStudio.Core.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="YamlDotNet" Version="15.1.2" />
+  </ItemGroup>
+
 </Project>

--- a/RefactorStudio.Core/Services/RecipeLoader.cs
+++ b/RefactorStudio.Core/Services/RecipeLoader.cs
@@ -1,0 +1,19 @@
+using RefactorStudio.Core.Models;
+using YamlDotNet.Serialization;
+
+namespace RefactorStudio.Core.Services;
+
+public static class RecipeLoader
+{
+    public static RecipeYaml Load(string path)
+    {
+        var yaml = File.ReadAllText(path);
+        var deserializer = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
+        var recipe = deserializer.Deserialize<RecipeYaml>(yaml);
+        if (recipe == null)
+        {
+            throw new InvalidOperationException("Invalid recipe file.");
+        }
+        return recipe;
+    }
+}

--- a/RefactorStudio.Core/Services/RecipeRunnerYaml.cs
+++ b/RefactorStudio.Core/Services/RecipeRunnerYaml.cs
@@ -1,0 +1,25 @@
+using RefactorStudio.Core.Models;
+
+namespace RefactorStudio.Core.Services;
+
+public class RecipeRunnerYaml
+{
+    private readonly IModelAdapter _adapter;
+
+    public RecipeRunnerYaml(IModelAdapter adapter)
+    {
+        _adapter = adapter;
+    }
+
+    public async Task RunAsync(RecipeYaml recipe)
+    {
+        var baseDir = Path.Combine("outputs", recipe.Id);
+        Directory.CreateDirectory(baseDir);
+        foreach (var step in recipe.Steps)
+        {
+            var result = await _adapter.ExecuteAsync(step.Prompt);
+            var file = Path.Combine(baseDir, $"{step.Name}.txt");
+            await File.WriteAllTextAsync(file, result);
+        }
+    }
+}

--- a/RefactorStudio.Recipes/samples/echo.yaml
+++ b/RefactorStudio.Recipes/samples/echo.yaml
@@ -1,0 +1,8 @@
+id: echo
+version: "1"
+description: Echo sample recipe
+steps:
+  - name: first
+    prompt: "Hello"
+  - name: second
+    prompt: "World"

--- a/RefactorStudio.Tests/RecipeRunnerTests.cs
+++ b/RefactorStudio.Tests/RecipeRunnerTests.cs
@@ -1,0 +1,47 @@
+using RefactorStudio.Core.Models;
+using RefactorStudio.Core.Services;
+using System.IO;
+
+namespace RefactorStudio.Tests;
+
+public class RecipeRunnerTests
+{
+    private class StubAdapter : IModelAdapter
+    {
+        public Task<string> ExecuteAsync(string prompt) => Task.FromResult(prompt + "-result");
+    }
+
+    [Fact]
+    public async Task RunAsync_WritesOutputsPerStep()
+    {
+        var recipe = new RecipeYaml
+        {
+            Id = "test",
+            Version = "1",
+            Steps = new List<RecipeStep>
+            {
+                new() { Name = "step1", Prompt = "p1" },
+                new() { Name = "step2", Prompt = "p2" }
+            }
+        };
+
+        var runner = new RecipeRunnerYaml(new StubAdapter());
+        await runner.RunAsync(recipe);
+
+        var dir = Path.Combine("outputs", "test");
+        try
+        {
+            var output1 = Path.Combine(dir, "step1.txt");
+            var output2 = Path.Combine(dir, "step2.txt");
+            Assert.True(File.Exists(output1));
+            Assert.True(File.Exists(output2));
+            Assert.Equal("p1-result", await File.ReadAllTextAsync(output1));
+            Assert.Equal("p2-result", await File.ReadAllTextAsync(output2));
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, true);
+        }
+    }
+}


### PR DESCRIPTION
@jp63670

## Summary
- add Run Recipe button to select and execute YAML recipes
- implement core recipe loader and runner services
- cover recipe runner with xUnit tests

## Testing
- `dotnet test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bacd43ec6c832d929f2362341fb655