### PR TITLE
fix: record outputs per recipe step

### DIFF
--- a/RefactorStudio.Core/Services/RecipeRunnerYaml.cs
+++ b/RefactorStudio.Core/Services/RecipeRunnerYaml.cs
@@ -20,6 +20,7 @@ public class RecipeRunnerYaml
             var result = await _adapter.ExecuteAsync(step.Prompt);
             var file = Path.Combine(baseDir, $"{step.Name}.txt");
             await File.WriteAllTextAsync(file, result);
+            step.Outputs.Add(file);
         }
     }
 }

--- a/RefactorStudio.Tests/RecipeRunnerTests.cs
+++ b/RefactorStudio.Tests/RecipeRunnerTests.cs
@@ -35,6 +35,8 @@ public class RecipeRunnerTests
             var output2 = Path.Combine(dir, "step2.txt");
             Assert.True(File.Exists(output1));
             Assert.True(File.Exists(output2));
+            Assert.Contains(output1, recipe.Steps[0].Outputs);
+            Assert.Contains(output2, recipe.Steps[1].Outputs);
             Assert.Equal("p1-result", await File.ReadAllTextAsync(output1));
             Assert.Equal("p2-result", await File.ReadAllTextAsync(output2));
         }


### PR DESCRIPTION
## Summary
- record generated output file paths for each recipe step
- test: verify runner stores output file paths

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bae0c81fd4832dac72081553b460ae